### PR TITLE
Merge Force env-var use

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ task :upload, [:version, :stack, :staging] do |t, args|
   credentials  = AWS::Core::CredentialProviders::SharedCredentialFileProvider.new(profile_name: profile_name)
   filename     = "ruby-#{args[:version]}.tgz"
   s3_key       = "#{args[:stack]}/#{filename.sub(/-(preview|rc)\d+/, '')}"
-  s3           = AWS::S3.new(credential_provider: credentials)
+  s3           = AWS::S3.new(access_key_id: ENV.fetch("AWS_ACCESS_KEY_ID"), secret_access_key: ENV.fetch("AWS_SECRET_ACCESS_KEY"))
   bucket       = s3.buckets[profile_name]
   object       = bucket.objects[s3_key]
   output_file  = "builds/#{args[:stack]}/#{filename}"


### PR DESCRIPTION
I don’t know how the SharedCredentialFileProvider, works. Can you give me some notes on how you set up a fail locally or what it’s called? 

It looks like there is a default key saved in `~/.aws/credentials` but even when I changed those values to the correct key and secret it did not work.