### PR TITLE
Generate new binaries for 16 and 18 with enable-shared

### DIFF
--- a/build.rb
+++ b/build.rb
@@ -150,7 +150,7 @@ Dir.mktmpdir("ruby-vendor-") do |vendor_dir|
 
     configure_opts = "--disable-install-doc --prefix #{prefix}"
     configure_opts += " --enable-load-relative" if major_ruby != "1.8" && version != "1.9.2"
-    if stack == "heroku-16"
+    if stack != "cedar-14"
       configure_opts += " --enable-shared"
     end
     puts "configure env:  #{configure_env}"


### PR DESCRIPTION
The `--enable-shared` flag will generate a `.so` that other languages (such as c++) can link against. This can be used for building native extensions with other languages than `c` an example https://rubygems.org/gems/rice


Don't forget to re-generate images:

```
bundle exec rake generate_image[cedar-14]
bundle exec rake generate_image[heroku-16]
bundle exec rake generate_image[heroku-18]
```